### PR TITLE
make phpsu php 7.0 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - "7.0"
   - "7.1"
   - "7.2"
   - "7.3"
@@ -14,6 +15,12 @@ env:
     - SYMFONY_VERSION="3.2.*"
     - SYMFONY_VERSION="3.4.*"
     - SYMFONY_VERSION="4.2.*"
+
+matrix:
+  exclude:
+    - php: "7.0"
+      env: SYMFONY_VERSION="4.2.*"
+
 
 install: composer require symfony/process:$SYMFONY_VERSION symfony/console:$SYMFONY_VERSION
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ composer require --dev phpsu/phpsu
 
 The following versions of PHP are supported by this version.
 
-* PHP `7.1`, `7.2` and `7.3`
+* PHP `7.0`, `7.1`, `7.2` and `7.3`
 * Compatible and continuously tested with symfony `3.2`, `3.4` and `4.2`
 
 Required for synchronisation are:

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,6 @@
   ],
   "homepage": "https://phpsu.de/",
   "config": {
-    "platform": {
-      "php": "7.1.3"
-    },
     "optimize-autoloader": true,
     "process-timeout": 0
   },
@@ -53,11 +50,11 @@
   "require": {
     "symfony/console": "3.2.* | 3.4.* | 4.2.*",
     "symfony/process": "3.2.* | 3.4.* | 4.2.*",
-    "php": ">=7.1.3 <7.4",
+    "php": ">=7.0.0 <7.4",
     "ext-json": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "7.*",
+    "phpunit/phpunit": "6.* | 7.*",
     "pluswerk/grumphp-config": "2.*",
     "spatie/phpunit-watcher": "1.*"
   },

--- a/phpsu
+++ b/phpsu
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
-if (version_compare('7.1.0', PHP_VERSION, '>')) {
-    fwrite(STDERR, 'phpsu works only with php version >=7.1 your version is: ' . PHP_VERSION . PHP_EOL);
+if (version_compare('7.0.0', PHP_VERSION, '>')) {
+    fwrite(STDERR, 'phpsu works only with php version >=7.0 your version is: ' . PHP_VERSION . PHP_EOL);
     die();
 }
 

--- a/src/Cli/InfoCliCommand.php
+++ b/src/Cli/InfoCliCommand.php
@@ -11,7 +11,10 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 class InfoCliCommand extends AbstractCliCommand
 {
-    public function configure(): void
+    /**
+     * @return void
+     */
+    public function configure()
     {
         $this->setName('info')
             ->setDescription('show version information of all instances')
@@ -26,7 +29,10 @@ class InfoCliCommand extends AbstractCliCommand
         $this->printDependencyVersions($output, $symfonyStyle);
     }
 
-    public function printDependencyVersions(OutputInterface $output, SymfonyStyle $symfonyStyle): void
+    /**
+     * @return void
+     */
+    public function printDependencyVersions(OutputInterface $output, SymfonyStyle $symfonyStyle)
     {
         $environmentUtility = new EnvironmentUtility();
         $output->writeln('<info>Locally installed</info>');

--- a/src/Cli/SshCliCommand.php
+++ b/src/Cli/SshCliCommand.php
@@ -17,7 +17,10 @@ final class SshCliCommand extends AbstractCliCommand
     /** @var null|string[] */
     private $instances;
 
-    protected function configure(): void
+    /**
+     * @return void
+     */
+    protected function configure()
     {
         $this->setName('ssh')
             ->setDescription('create SSH Connection')
@@ -28,7 +31,10 @@ final class SshCliCommand extends AbstractCliCommand
             ->addArgument('commands', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'The Destination AppInstance.', []);
     }
 
-    protected function initialize(InputInterface $input, OutputInterface $output): void
+    /**
+     * @return void
+     */
+    protected function initialize(InputInterface $input, OutputInterface $output)
     {
         $default = $input->hasArgument('destination') ? $input->getArgument('destination') : '';
         if ($default) {
@@ -39,7 +45,10 @@ final class SshCliCommand extends AbstractCliCommand
         }
     }
 
-    protected function interact(InputInterface $input, OutputInterface $output): void
+    /**
+     * @return void
+     */
+    protected function interact(InputInterface $input, OutputInterface $output)
     {
         $default = $input->hasArgument('destination') ? $input->getArgument('destination') : '';
         if (!\in_array($default, $this->getAppInstancesWithHost(), true)) {

--- a/src/Cli/SyncCliCommand.php
+++ b/src/Cli/SyncCliCommand.php
@@ -12,8 +12,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 final class SyncCliCommand extends AbstractCliCommand
 {
-
-    protected function configure(): void
+    /**
+     * @return void
+     */
+    protected function configure()
     {
         $this->setName('sync')
             ->setDescription('Sync AppInstances')

--- a/src/Config/FileSystems.php
+++ b/src/Config/FileSystems.php
@@ -8,7 +8,10 @@ final class FileSystems
     /** @var FileSystem[] */
     private $fileSystems = [];
 
-    public function add(Filesystem $filesystem): void
+    /**
+     * @return void
+     */
+    public function add(Filesystem $filesystem)
     {
         $this->fileSystems[$filesystem->getName()] = $filesystem;
     }

--- a/src/Config/GlobalConfig.php
+++ b/src/Config/GlobalConfig.php
@@ -105,9 +105,10 @@ final class GlobalConfig
 
     /**
      * @param string $host
+     * @return void
      * @throws \Exception
      */
-    public function validateConnectionToHost(string $host): void
+    public function validateConnectionToHost(string $host)
     {
         $this->sshConnections->getPossibilities($host);
     }

--- a/src/Config/SshConfig.php
+++ b/src/Config/SshConfig.php
@@ -26,7 +26,10 @@ final class SshConfig
         return $this->hosts[$name];
     }
 
-    public function __set(string $name, SshConfigHost $host): void
+    /**
+     * @return void
+     */
+    public function __set(string $name, SshConfigHost $host)
     {
         $this->hosts[$name] = $host;
     }
@@ -36,12 +39,18 @@ final class SshConfig
         return $this->file;
     }
 
-    public function setFile(\SplFileObject $file): void
+    /**
+     * @return void
+     */
+    public function setFile(\SplFileObject $file)
     {
         $this->file = $file;
     }
 
-    public function writeConfig(): void
+    /**
+     * @return void
+     */
+    public function writeConfig()
     {
         $this->file->ftruncate(0);
         $this->file->fwrite($this->toFileString());

--- a/src/Config/SshConfigHost.php
+++ b/src/Config/SshConfigHost.php
@@ -24,7 +24,10 @@ final class SshConfigHost
         return $this->options[$name];
     }
 
-    public function __set(string $name, string $config): void
+    /**
+     * @return void
+     */
+    public function __set(string $name, string $config)
     {
         $this->options[$name] = $config;
     }

--- a/src/Config/SshConnections.php
+++ b/src/Config/SshConnections.php
@@ -7,14 +7,20 @@ final class SshConnections
 {
     private $connections = [];
 
-    public function addConnections(SshConnection ...$sshConnections): void
+    /**
+     * @return void
+     */
+    public function addConnections(SshConnection ...$sshConnections)
     {
         foreach ($sshConnections as $sshConnection) {
             $this->add($sshConnection);
         }
     }
 
-    public function add(SshConnection $sshConnection): void
+    /**
+     * @return void
+     */
+    public function add(SshConnection $sshConnection)
     {
         if (count($sshConnection->getFrom()) === 0) {
             $this->addSingleConnection('', $sshConnection);
@@ -25,7 +31,10 @@ final class SshConnections
         }
     }
 
-    private function addSingleConnection(string $from, SshConnection $sshConnection): void
+    /**
+     * @return void
+     */
+    private function addSingleConnection(string $from, SshConnection $sshConnection)
     {
         if (isset($this->connections[$sshConnection->getHost()][$from])) {
             throw new \Exception(sprintf('suspicious Connection Model found: %s->%s has more than one definition', $from, $sshConnection->getHost()));

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 final class Controller implements ControllerInterface
 {
-    public const PHPSU_ROOT_PATH = __DIR__ . '/../';
+    const PHPSU_ROOT_PATH = __DIR__ . '/../';
 
     public function ssh(OutputInterface $output, GlobalConfig $config, SshOptions $options): int
     {
@@ -27,7 +27,10 @@ final class Controller implements ControllerInterface
         return (new CommandExecutor())->passthru($sshCommand);
     }
 
-    public function sync(OutputInterface $output, GlobalConfig $config, SyncOptions $options): void
+    /**
+     * @return void
+     */
+    public function sync(OutputInterface $output, GlobalConfig $config, SyncOptions $options)
     {
         $commands = (new CommandGenerator($config, $output->getVerbosity()))->syncCommands($options);
 

--- a/src/ControllerInterface.php
+++ b/src/ControllerInterface.php
@@ -12,5 +12,8 @@ interface ControllerInterface
 {
     public function ssh(OutputInterface $output, GlobalConfig $config, SshOptions $options): int;
 
-    public function sync(OutputInterface $output, GlobalConfig $config, SyncOptions $options): void;
+    /**
+     * @return void
+     */
+    public function sync(OutputInterface $output, GlobalConfig $config, SyncOptions $options);
 }

--- a/src/Helper/ApplicationHelper.php
+++ b/src/Helper/ApplicationHelper.php
@@ -15,12 +15,18 @@ final class ApplicationHelper
         return $this->getPhpSuVersionFromVendor() ?? $this->getPhpSuVersionFromGitFolder() ?? 'development';
     }
 
-    private function getPhpSuVersionFromVendor(): ?string
+    /**
+     * @return string|null
+     */
+    private function getPhpSuVersionFromVendor()
     {
         return (new EnvironmentUtility())->getInstalledPackageVersion('phpsu/phpsu');
     }
 
-    private function getPhpSuVersionFromGitFolder(): ?string
+    /**
+     * @return string|null
+     */
+    private function getPhpSuVersionFromGitFolder()
     {
         if (!file_exists(Controller::PHPSU_ROOT_PATH . '/.git/')) {
             return null;

--- a/src/Helper/StringHelper.php
+++ b/src/Helper/StringHelper.php
@@ -29,7 +29,10 @@ final class StringHelper
         return [$full];
     }
 
-    public static function findStringInArray(string $needle, array $haystack): ?string
+    /**
+     * @return string|null
+     */
+    public static function findStringInArray(string $needle, array $haystack)
     {
         $remaining = array_filter($haystack, function ($el) use ($needle) {
             return stripos($el, $needle) === 0;

--- a/src/Polyfills/ConsoleSectionOutput.php
+++ b/src/Polyfills/ConsoleSectionOutput.php
@@ -33,8 +33,9 @@ class ConsoleSectionOutput extends StreamOutput
      * Clears previous output for this section.
      *
      * @param int $lines Number of lines to clear. If null, then the entire output of this section is cleared
+     * @return void
      */
-    public function clear(int $lines = null): void
+    public function clear(int $lines = null)
     {
         if (empty($this->content) || !$this->isDecorated()) {
             return;
@@ -53,8 +54,9 @@ class ConsoleSectionOutput extends StreamOutput
      * Overwrites the previous output with a new message.
      *
      * @param array|string $message
+     * @return void
      */
-    public function overwrite($message): void
+    public function overwrite($message)
     {
         $this->clear();
         $this->writeln($message);
@@ -67,9 +69,10 @@ class ConsoleSectionOutput extends StreamOutput
 
     /**
      * @param string $input
+     * @return void
      * @internal
      */
-    public function addContent(string $input): void
+    public function addContent(string $input)
     {
         foreach (explode(PHP_EOL, $input) as $lineContent) {
             $this->lines += ceil($this->getDisplayLength($lineContent) / $this->terminal->getWidth()) ?: 1;

--- a/src/Process/CommandExecutor.php
+++ b/src/Process/CommandExecutor.php
@@ -14,7 +14,7 @@ final class CommandExecutor
      * @param OutputInterface $statusOutput
      * @return void
      */
-    public function executeParallel(array $commands, OutputInterface $logOutput, OutputInterface $statusOutput): void
+    public function executeParallel(array $commands, OutputInterface $logOutput, OutputInterface $statusOutput)
     {
         $manager = new ProcessManager();
         foreach ($commands as $name => $command) {

--- a/src/Process/OutputCallback.php
+++ b/src/Process/OutputCallback.php
@@ -17,7 +17,10 @@ final class OutputCallback
         $this->output = $output;
     }
 
-    public function __invoke(Process $process, string $type, string $data): void
+    /**
+     * @return void
+     */
+    public function __invoke(Process $process, string $type, string $data)
     {
         $output = $this->output;
         $verbosity = OutputInterface::VERBOSITY_VERBOSE;

--- a/src/Process/Process.php
+++ b/src/Process/Process.php
@@ -8,10 +8,10 @@ use PHPSu\Tools\EnvironmentUtility;
 
 final class Process extends \Symfony\Component\Process\Process
 {
-    public const STATE_READY = 'ready';
-    public const STATE_RUNNING = 'running';
-    public const STATE_SUCCEEDED = 'succeeded';
-    public const STATE_ERRORED = 'errored';
+    const STATE_READY = 'ready';
+    const STATE_RUNNING = 'running';
+    const STATE_SUCCEEDED = 'succeeded';
+    const STATE_ERRORED = 'errored';
 
     /** @var string */
     private $name = '';
@@ -40,7 +40,7 @@ final class Process extends \Symfony\Component\Process\Process
         throw new \LogicException('This should never happen');
     }
 
-    public function __construct($commandline, ?string $cwd = null, ?array $env = null, $input = null, ?float $timeout = 60, array $options = [])
+    public function __construct($commandline, string $cwd = null, array $env = null, $input = null, $timeout = 60.0, array $options = [])
     {
         if (\is_array($commandline) && version_compare((new EnvironmentUtility())->getSymfonyProcessVersion(), '3.4.0', '<')) {
             throw new CommandExecutionException('Support for arrays as commandline-argument is not supported in symfony < 3.4.0');
@@ -57,7 +57,7 @@ final class Process extends \Symfony\Component\Process\Process
      *
      * {@inheritdoc}
      */
-    public static function fromShellCommandline(string $command, string $cwd = null, array $env = null, $input = null, ?float $timeout = 60): self
+    public static function fromShellCommandline(string $command, string $cwd = null, array $env = null, $input = null, float $timeout = null): self
     {
         if (version_compare((new EnvironmentUtility())->getSymfonyProcessVersion(), '4.2.0', '>=')) {
             /** @noinspection PhpUndefinedMethodInspection Symfony version > 4.X */

--- a/src/Process/Spinner.php
+++ b/src/Process/Spinner.php
@@ -5,7 +5,7 @@ namespace PHPSu\Process;
 
 final class Spinner
 {
-    public const PONG = [
+    const PONG = [
         '(      )',
         '(●     )',
         '( ●    )',

--- a/src/Process/StateChangeCallback.php
+++ b/src/Process/StateChangeCallback.php
@@ -29,7 +29,10 @@ final class StateChangeCallback
         }
     }
 
-    private function sectionCall(ConsoleSectionOutput $sectionOutput, ProcessManager $manager): void
+    /**
+     * @return void
+     */
+    private function sectionCall(ConsoleSectionOutput $sectionOutput, ProcessManager $manager)
     {
         $lines = [];
         foreach ($manager->getProcesses() as $processId => $process) {
@@ -38,7 +41,10 @@ final class StateChangeCallback
         $sectionOutput->overwrite(implode(PHP_EOL, $lines));
     }
 
-    private function normalCall(int $processId, Process $process, string $state): void
+    /**
+     * @return void
+     */
+    private function normalCall(int $processId, Process $process, string $state)
     {
         $this->output->writeln($this->getMessage($processId, $state, $process->getName()));
     }

--- a/src/Tools/EnvironmentUtility.php
+++ b/src/Tools/EnvironmentUtility.php
@@ -82,7 +82,10 @@ final class EnvironmentUtility
         ];
     }
 
-    public function getInstalledPackageVersion(string $packageName): ?string
+    /**
+     * @return string|null
+     */
+    public function getInstalledPackageVersion(string $packageName)
     {
         $activeInstallations = json_decode(file_get_contents($this->spotVendorPath() . '/composer/installed.json'));
         foreach ($activeInstallations as $installed) {

--- a/tests/Cli/InfoCliCommandTest.php
+++ b/tests/Cli/InfoCliCommandTest.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 class InfoCliCommandTest extends TestCase
 {
-    public function testPrintDependencyVersionsLocally(): void
+    public function testPrintDependencyVersionsLocally()
     {
         $command = new InfoCliCommand(new ConfigurationLoader(), new Controller());
 

--- a/tests/Cli/PhpsuApplicationTest.php
+++ b/tests/Cli/PhpsuApplicationTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 class PhpsuApplicationTest extends TestCase
 {
-    public function testPhpsuApplicationCommand(): void
+    public function testPhpsuApplicationCommand()
     {
         $app = PhpsuApplication::createApplication();
         $this->assertInstanceOf(SyncCliCommand::class, $app->get('sync'));

--- a/tests/Cli/SshCliCommandTest.php
+++ b/tests/Cli/SshCliCommandTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 class SshCliCommandTest extends TestCase
 {
 
-    public function testSshCliCommandDryRun(): void
+    public function testSshCliCommandDryRun()
     {
         $mockConfigurationLoader = $this->createMockConfigurationLoader($this->createConfig());
 
@@ -39,7 +39,7 @@ class SshCliCommandTest extends TestCase
         $this->assertSame(0, $commandTester->getStatusCode());
     }
 
-    public function testSshCliCommandDryRunInteractive(): void
+    public function testSshCliCommandDryRunInteractive()
     {
         $mockConfigurationLoader = $this->createMockConfigurationLoader($this->createConfig());
 
@@ -61,7 +61,7 @@ class SshCliCommandTest extends TestCase
         $this->assertSame(0, $commandTester->getStatusCode());
     }
 
-    public function testSshCliCommandExecute(): void
+    public function testSshCliCommandExecute()
     {
         $globalConfig = $this->createConfig();
         $mockConfigurationLoader = $this->createMockConfigurationLoader($globalConfig);

--- a/tests/Command/CommandGeneratorTest.php
+++ b/tests/Command/CommandGeneratorTest.php
@@ -34,7 +34,7 @@ final class CommandGeneratorTest extends TestCase
         return $globalConfig;
     }
 
-    public function testSshGeneration(): void
+    public function testSshGeneration()
     {
         $globalConfig = static::getGlobalConfig();
         $commandGenerator = new CommandGenerator($globalConfig);
@@ -43,7 +43,7 @@ final class CommandGeneratorTest extends TestCase
         $this->assertSame("ssh -F 'php://temp' 'serverEu' -t 'cd '\''/var/www/production'\''; bash --login'", $result);
     }
 
-    public function testSshWithCommand(): void
+    public function testSshWithCommand()
     {
         $globalConfig = static::getGlobalConfig();
         $commandGenerator = new CommandGenerator($globalConfig);
@@ -58,14 +58,14 @@ final class CommandGeneratorTest extends TestCase
      * @expectedException \Exception
      * @expectedExceptionMessage Source and Destination are Identical: same
      */
-    public function testFromAndToSameDisallowed(): void
+    public function testFromAndToSameDisallowed()
     {
         $globalConfig = static::getGlobalConfig();
         $commandGenerator = new CommandGenerator($globalConfig);
         $commandGenerator->syncCommands((new SyncOptions('same'))->setDestination('same'));
     }
 
-    public function testProductionToLocalFromAnyThere(): void
+    public function testProductionToLocalFromAnyThere()
     {
         $globalConfig = static::getGlobalConfig();
         $commandGenerator = new CommandGenerator($globalConfig);
@@ -94,7 +94,7 @@ SSH_CONFIG;
         $this->assertSame($expectedSshConfigString, implode('', iterator_to_array($file)));
     }
 
-    public function testProductionToTestingFromAnyThere(): void
+    public function testProductionToTestingFromAnyThere()
     {
         $globalConfig = static::getGlobalConfig();
         $commandGenerator = new CommandGenerator($globalConfig);
@@ -123,7 +123,7 @@ SSH_CONFIG;
         $this->assertSame($expectedSshConfigString, implode('', iterator_to_array($file)));
     }
 
-    public function testLocalToLocal2FromAnyThere(): void
+    public function testLocalToLocal2FromAnyThere()
     {
         $globalConfig = static::getGlobalConfig();
         $commandGenerator = new CommandGenerator($globalConfig);
@@ -152,7 +152,7 @@ SSH_CONFIG;
         $this->assertSame($expectedSshConfigString, implode('', iterator_to_array($file)));
     }
 
-    public function testProductionToStagingFromAnyThere(): void
+    public function testProductionToStagingFromAnyThere()
     {
         $globalConfig = static::getGlobalConfig();
         $commandGenerator = new CommandGenerator($globalConfig);
@@ -181,7 +181,7 @@ SSH_CONFIG;
         $this->assertSame($expectedSshConfigString, implode('', iterator_to_array($file)));
     }
 
-    public function testProductionToStagingFromStaging(): void
+    public function testProductionToStagingFromStaging()
     {
         $globalConfig = static::getGlobalConfig();
         $commandGenerator = new CommandGenerator($globalConfig);
@@ -206,7 +206,7 @@ SSH_CONFIG;
         $this->assertSame($expectedSshConfigString, implode('', iterator_to_array($file)));
     }
 
-    public function testStagingToProductionFromStaging(): void
+    public function testStagingToProductionFromStaging()
     {
         $globalConfig = static::getGlobalConfig();
         $commandGenerator = new CommandGenerator($globalConfig);

--- a/tests/Command/DatabaseCommandTest.php
+++ b/tests/Command/DatabaseCommandTest.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 final class DatabaseCommandTest extends TestCase
 {
-    public function testDatabaseCommandGenerate(): void
+    public function testDatabaseCommandGenerate()
     {
         $sshConfig = new SshConfig();
         $sshConfig->setFile(new \SplTempFileObject());
@@ -24,7 +24,7 @@ final class DatabaseCommandTest extends TestCase
         $this->assertSame("ssh -F 'php://temp' 'hostc' 'mysqldump --opt --skip-comments -h'\''database'\'' -u'\''root'\'' -p'\''root'\'' '\''sequelmovie'\''' | (echo 'CREATE DATABASE IF NOT EXISTS `sequelmovie2`;USE `sequelmovie2`;' && cat) | mysql -h'127.0.0.1' -P2206 -u'root' -p'root'", $database->generate());
     }
 
-    public function testDatabaseCommandQuiet(): void
+    public function testDatabaseCommandQuiet()
     {
         $sshConfig = new SshConfig();
         $sshConfig->setFile(new \SplTempFileObject());
@@ -39,7 +39,7 @@ final class DatabaseCommandTest extends TestCase
         $this->assertSame("ssh -q -F 'php://temp' 'hostc' 'mysqldump -q --opt --skip-comments -h'\''database'\'' -u'\''root'\'' -p'\''root'\'' '\''sequelmovie'\''' | (echo 'CREATE DATABASE IF NOT EXISTS `sequelmovie2`;USE `sequelmovie2`;' && cat) | mysql -h'127.0.0.1' -P2206 -u'root' -p'root'", $database->generate());
     }
 
-    public function testDatabaseCommandVerbose(): void
+    public function testDatabaseCommandVerbose()
     {
         $sshConfig = new SshConfig();
         $sshConfig->setFile(new \SplTempFileObject());
@@ -54,7 +54,7 @@ final class DatabaseCommandTest extends TestCase
         $this->assertSame("ssh -v -F 'php://temp' 'hostc' 'mysqldump -v --opt --skip-comments -h'\''database'\'' -u'\''root'\'' -p'\''root'\'' '\''sequelmovie'\''' | (echo 'CREATE DATABASE IF NOT EXISTS `sequelmovie2`;USE `sequelmovie2`;' && cat) | mysql -h'127.0.0.1' -P2206 -u'root' -p'root'", $database->generate());
     }
 
-    public function testDatabaseCommandVeryVerbose(): void
+    public function testDatabaseCommandVeryVerbose()
     {
         $sshConfig = new SshConfig();
         $sshConfig->setFile(new \SplTempFileObject());
@@ -69,7 +69,7 @@ final class DatabaseCommandTest extends TestCase
         $this->assertSame("ssh -vv -F 'php://temp' 'hostc' 'mysqldump -vv --opt --skip-comments -h'\''database'\'' -u'\''root'\'' -p'\''root'\'' '\''sequelmovie'\''' | (echo 'CREATE DATABASE IF NOT EXISTS `sequelmovie2`;USE `sequelmovie2`;' && cat) | mysql -h'127.0.0.1' -P2206 -u'root' -p'root'", $database->generate());
     }
 
-    public function testDatabaseCommandDebug(): void
+    public function testDatabaseCommandDebug()
     {
         $sshConfig = new SshConfig();
         $sshConfig->setFile(new \SplTempFileObject());

--- a/tests/Command/RsyncCommandTest.php
+++ b/tests/Command/RsyncCommandTest.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 final class RsyncCommandTest extends TestCase
 {
 
-    public function testRsyncWithAppInstance(): void
+    public function testRsyncWithAppInstance()
     {
         $sshConfig = new SshConfig();
         $sshConfig->setFile(new \SplTempFileObject());
@@ -33,7 +33,7 @@ final class RsyncCommandTest extends TestCase
         $this->assertSame("rsync -az -e 'ssh -F '\''php://temp'\''' 'hosta:/var/www/prod/' 'hostc:/var/www/testing/'", $generated);
     }
 
-    public function testGenerate(): void
+    public function testGenerate()
     {
         $sshConfig = new SshConfig();
         $sshConfig->setFile(new \SplTempFileObject());
@@ -47,7 +47,7 @@ final class RsyncCommandTest extends TestCase
         $this->assertSame("rsync -r -e 'ssh -F '\''php://temp'\''' 'hosta:~/test/*' './__test/'", $rsync->generate());
     }
 
-    public function testRsyncWithAppInstanceLocal(): void
+    public function testRsyncWithAppInstanceLocal()
     {
         $sshConfig = new SshConfig();
         $sshConfig->setFile(new \SplTempFileObject());
@@ -65,7 +65,7 @@ final class RsyncCommandTest extends TestCase
         $this->assertSame("rsync -az -e 'ssh -F '\''php://temp'\''' 'hosta:/var/www/prod/' './'", $generated);
     }
 
-    public function testLocalAndVarStorage(): void
+    public function testLocalAndVarStorage()
     {
         $sshConfig = new SshConfig();
         $sshConfig->setFile(new \SplTempFileObject());
@@ -83,7 +83,7 @@ final class RsyncCommandTest extends TestCase
         $this->assertSame("rsync -az -e 'ssh -F '\''php://temp'\''' 'hosta:/var/www/prod/var/storage/' './var/storage/'", $generated);
     }
 
-    public function testRsyncQuiet(): void
+    public function testRsyncQuiet()
     {
         $sshConfig = new SshConfig();
         $sshConfig->setFile(new \SplTempFileObject());
@@ -101,7 +101,7 @@ final class RsyncCommandTest extends TestCase
         $this->assertSame("rsync -q -az -e 'ssh -F '\''php://temp'\''' 'hosta:/var/www/prod/var/storage/' './var/storage/'", $generated);
     }
 
-    public function testRsyncVerbose(): void
+    public function testRsyncVerbose()
     {
         $sshConfig = new SshConfig();
         $sshConfig->setFile(new \SplTempFileObject());
@@ -119,7 +119,7 @@ final class RsyncCommandTest extends TestCase
         $this->assertSame("rsync -v -az -e 'ssh -F '\''php://temp'\''' 'hosta:/var/www/prod/var/storage/' './var/storage/'", $generated);
     }
 
-    public function testRsyncVeryVerbose(): void
+    public function testRsyncVeryVerbose()
     {
         $sshConfig = new SshConfig();
         $sshConfig->setFile(new \SplTempFileObject());
@@ -137,7 +137,7 @@ final class RsyncCommandTest extends TestCase
         $this->assertSame("rsync -vv -az -e 'ssh -F '\''php://temp'\''' 'hosta:/var/www/prod/var/storage/' './var/storage/'", $generated);
     }
 
-    public function testRsyncDebug(): void
+    public function testRsyncDebug()
     {
         $sshConfig = new SshConfig();
         $sshConfig->setFile(new \SplTempFileObject());

--- a/tests/Command/SshCommandTest.php
+++ b/tests/Command/SshCommandTest.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 final class SshCommandTest extends TestCase
 {
-    public function testSshCommandGenerate(): void
+    public function testSshCommandGenerate()
     {
         $sshConfig = new SshConfig();
         $sshConfig->setFile(new \SplTempFileObject());
@@ -21,7 +21,7 @@ final class SshCommandTest extends TestCase
         $this->assertSame("ssh -F 'php://temp' 'hosta'", $ssh->generate());
     }
 
-    public function testSshCommandQuiet(): void
+    public function testSshCommandQuiet()
     {
         $sshConfig = new SshConfig();
         $sshConfig->setFile(new \SplTempFileObject());
@@ -32,7 +32,7 @@ final class SshCommandTest extends TestCase
         $this->assertSame("ssh -q -F 'php://temp' 'hosta'", $ssh->generate());
     }
 
-    public function testSshCommandVerbose(): void
+    public function testSshCommandVerbose()
     {
         $sshConfig = new SshConfig();
         $sshConfig->setFile(new \SplTempFileObject());
@@ -43,7 +43,7 @@ final class SshCommandTest extends TestCase
         $this->assertSame("ssh -v -F 'php://temp' 'hosta'", $ssh->generate());
     }
 
-    public function testSshCommandVeryVerbose(): void
+    public function testSshCommandVeryVerbose()
     {
         $sshConfig = new SshConfig();
         $sshConfig->setFile(new \SplTempFileObject());
@@ -54,7 +54,7 @@ final class SshCommandTest extends TestCase
         $this->assertSame("ssh -vv -F 'php://temp' 'hosta'", $ssh->generate());
     }
 
-    public function testSshCommandDebug(): void
+    public function testSshCommandDebug()
     {
         $sshConfig = new SshConfig();
         $sshConfig->setFile(new \SplTempFileObject());
@@ -69,7 +69,7 @@ final class SshCommandTest extends TestCase
      * @expectedException \Exception
      * @expectedExceptionMessage  the found host and the current Host are the same: same
      */
-    public function testSameException(): void
+    public function testSameException()
     {
         $sshConfig = new SshConfig();
         $sshConfig->setFile(new \SplTempFileObject());

--- a/tests/Config/AppInstancesTest.php
+++ b/tests/Config/AppInstancesTest.php
@@ -12,19 +12,19 @@ final class AppInstancesTest extends TestCase
     /**
      * @expectedException \Exception
      */
-    public function testGetException(): void
+    public function testGetException()
     {
         $apps = new AppInstances();
         $apps->get('NameNotInApps');
     }
 
-    public function testGetAll(): void
+    public function testGetAll()
     {
         $apps = new AppInstances();
         $this->assertSame([], $apps->getAll());
     }
 
-    public function testGetAllOneInstance(): void
+    public function testGetAllOneInstance()
     {
         $apps = new AppInstances();
         $name = 'TestInstance';

--- a/tests/Config/ConfigurationLoaderTest.php
+++ b/tests/Config/ConfigurationLoaderTest.php
@@ -18,7 +18,7 @@ final class ConfigurationLoaderTest extends TestCase
         chdir(__DIR__ . '/../fixtures');
     }
 
-    public function testGetConfig(): void
+    public function testGetConfig()
     {
         $configurationLoader = new ConfigurationLoader();
         $this->assertEquals(new GlobalConfig(), $configurationLoader->getConfig());

--- a/tests/Config/DatabasesTest.php
+++ b/tests/Config/DatabasesTest.php
@@ -11,7 +11,7 @@ final class DatabasesTest extends TestCase
     /**
      * @expectedException \Exception
      */
-    public function testGetException(): void
+    public function testGetException()
     {
         $databases = new Databases();
         $databases->get('NameNotInDatabases');

--- a/tests/Config/FileSystemsTest.php
+++ b/tests/Config/FileSystemsTest.php
@@ -11,7 +11,7 @@ final class FileSystemsTest extends TestCase
     /**
      * @expectedException \Exception
      */
-    public function testGetException(): void
+    public function testGetException()
     {
         $fileSystems = new FileSystems();
         $fileSystems->get('NameNotInDatabases');

--- a/tests/Config/GlobalConfigTest.php
+++ b/tests/Config/GlobalConfigTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 final class GlobalConfigTest extends TestCase
 {
-    public function testSshFromGlobalConfig(): void
+    public function testSshFromGlobalConfig()
     {
         $global = static::getGlobalConfig();
 
@@ -31,7 +31,7 @@ final class GlobalConfigTest extends TestCase
         $this->assertEquals((new SshCommand())->setInto('serverEu'), $sshCommand);
     }
 
-    public function testDatabaseFromGlobalConfig(): void
+    public function testDatabaseFromGlobalConfig()
     {
         $global = static::getGlobalConfig();
 
@@ -41,7 +41,7 @@ final class GlobalConfigTest extends TestCase
         ], $rsyncCommands);
     }
 
-    public function testRsyncFromGlobalConfig(): void
+    public function testRsyncFromGlobalConfig()
     {
         $global = static::getGlobalConfig();
 
@@ -52,7 +52,7 @@ final class GlobalConfigTest extends TestCase
         ], $rsyncCommands);
     }
 
-    public function testSshConfigFromGlobalConfig(): void
+    public function testSshConfigFromGlobalConfig()
     {
         $global = static::getGlobalConfig();
 
@@ -66,7 +66,7 @@ final class GlobalConfigTest extends TestCase
         $this->assertEquals($sshConfigExpected, $sshConfig);
     }
 
-    public function testOverwriteDefaultSshConfig(): void
+    public function testOverwriteDefaultSshConfig()
     {
         $global = static::getGlobalConfig();
         $global->setDefaultSshConfig(['ForwardAgent' => 'no']);

--- a/tests/Config/SshConfigGeneratorTest.php
+++ b/tests/Config/SshConfigGeneratorTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 
 final class SshConfigGeneratorTest extends TestCase
 {
-    public function testConnectionProblem(): void
+    public function testConnectionProblem()
     {
         // from everywhere
         $sshConnections = new SshConnections();
@@ -33,7 +33,7 @@ final class SshConfigGeneratorTest extends TestCase
         $this->assertEquals([$toA, $toCFromA], $path);
     }
 
-    public function testSshConfigGeneratorGenerate(): void
+    public function testSshConfigGeneratorGenerate()
     {
         $sshConnections = new SshConnections();
         $sshConnections->add(

--- a/tests/Config/SshConfigHostTest.php
+++ b/tests/Config/SshConfigHostTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 final class SshConfigHostTest extends TestCase
 {
 
-    public function testSetIssetGet(): void
+    public function testSetIssetGet()
     {
         $sshConfigHost = new SshConfigHost();
         $this->assertFalse(isset($sshConfigHost->User));

--- a/tests/Config/SshConfigTest.php
+++ b/tests/Config/SshConfigTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 final class SshConfigTest extends TestCase
 {
 
-    public function testWriteConfig(): void
+    public function testWriteConfig()
     {
         $sshConfig = new SshConfig();
         $sshConfig->setFile($file = new \SplTempFileObject());

--- a/tests/Config/SshConnectionsTest.php
+++ b/tests/Config/SshConnectionsTest.php
@@ -13,7 +13,7 @@ final class SshConnectionsTest extends TestCase
      * @expectedException \Exception
      * @expectedExceptionMessage suspicious Connection Model found: fromHere->test has more than one definition
      */
-    public function testAdd(): void
+    public function testAdd()
     {
         $sshConnections = new SshConnections();
         $sshConnections->add((new SshConnection())->setHost('test')->setFrom(['fromHere']));
@@ -24,7 +24,7 @@ final class SshConnectionsTest extends TestCase
      * @expectedException \Exception
      * @expectedExceptionMessage Host test not found in SshConnections
      */
-    public function testGetPossibilities(): void
+    public function testGetPossibilities()
     {
         $sshConnections = new SshConnections();
         $sshConnections->getPossibilities('test');

--- a/tests/Config/SshUrlTest.php
+++ b/tests/Config/SshUrlTest.php
@@ -8,21 +8,21 @@ use PHPUnit\Framework\TestCase;
 
 final class SshUrlTest extends TestCase
 {
-    public function testInvalidUrl(): void
+    public function testInvalidUrl()
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessageRegExp('/SshUrl could not been parsed/');
         new SshUrl('://:/:/:/:/');
     }
 
-    public function testInvalidUser(): void
+    public function testInvalidUser()
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessageRegExp('/User must be set/');
         new SshUrl('test');
     }
 
-    public function testInvalidPort(): void
+    public function testInvalidPort()
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessageRegExp('/port must be between 0 and 65535/');
@@ -30,7 +30,7 @@ final class SshUrlTest extends TestCase
         $dsn->setPort(1234567);
     }
 
-    public function testSshWithoutSchema(): void
+    public function testSshWithoutSchema()
     {
         $dsn = new SshUrl('user@host');
         $this->assertSame('user', $dsn->getUser());
@@ -40,7 +40,7 @@ final class SshUrlTest extends TestCase
         $this->assertSame('ssh://user@host', $dsn->__toString());
     }
 
-    public function testSshWithSchema(): void
+    public function testSshWithSchema()
     {
         $dsn = new SshUrl('ssh://user@host');
         $this->assertSame('user', $dsn->getUser());
@@ -50,7 +50,7 @@ final class SshUrlTest extends TestCase
         $this->assertSame('ssh://user@host', $dsn->__toString());
     }
 
-    public function testSshWithSchemaPort2206(): void
+    public function testSshWithSchemaPort2206()
     {
         $dsn = new SshUrl('ssh://user@host:2206');
         $this->assertSame('user', $dsn->getUser());
@@ -60,7 +60,7 @@ final class SshUrlTest extends TestCase
         $this->assertSame('ssh://user@host:2206', $dsn->__toString());
     }
 
-    public function testSshWithPassword(): void
+    public function testSshWithPassword()
     {
         $dsn = new SshUrl('ssh://user:password@host');
         $this->assertSame('user', $dsn->getUser());
@@ -70,7 +70,7 @@ final class SshUrlTest extends TestCase
         $this->assertSame('ssh://user:password@host', $dsn->__toString());
     }
 
-    public function testSshWithIp(): void
+    public function testSshWithIp()
     {
         $dsn = new SshUrl('user@192.168.0.1');
         $this->assertSame('user', $dsn->getUser());

--- a/tests/Config/TempSshConfigFileTest.php
+++ b/tests/Config/TempSshConfigFileTest.php
@@ -18,7 +18,7 @@ final class TempSshConfigFileTest extends TestCase
         exec(sprintf('rm -rf %s', escapeshellarg(__DIR__ . '/../fixtures/.phpsu/')));
     }
 
-    public function testConstruct(): void
+    public function testConstruct()
     {
         $file = new TempSshConfigFile();
         $this->assertSame('', implode('', iterator_to_array($file)));

--- a/tests/ControllerTest.php
+++ b/tests/ControllerTest.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Output\BufferedOutput;
 
 final class ControllerTest extends TestCase
 {
-    public function testEmptyConfigSshDryRun(): void
+    public function testEmptyConfigSshDryRun()
     {
         $output = new BufferedOutput();
         $config = new GlobalConfig();
@@ -24,7 +24,7 @@ final class ControllerTest extends TestCase
         $this->assertSame("ssh -F '.phpsu/config/ssh_config' 'serverEu' -t 'cd '\''/var/www/prod'\''; bash --login'\n", $output->fetch());
     }
 
-    public function testEmptyConfigSyncDryRun(): void
+    public function testEmptyConfigSyncDryRun()
     {
         $output = new BufferedOutput();
         $config = new GlobalConfig();
@@ -35,7 +35,7 @@ final class ControllerTest extends TestCase
         $this->assertSame('', $output->fetch());
     }
 
-    public function testFilesystemAndDatabase(): void
+    public function testFilesystemAndDatabase()
     {
         $config = new GlobalConfig();
         $config->addFilesystem('fileadmin', 'fileadmin');
@@ -58,7 +58,7 @@ final class ControllerTest extends TestCase
         $this->assertSame($lines, explode("\n", $output->fetch()));
     }
 
-    public function testExcludeShouldBePresentInRsyncCommand(): void
+    public function testExcludeShouldBePresentInRsyncCommand()
     {
         $config = new GlobalConfig();
         $config->addFilesystem('fileadmin', 'fileadmin')->addExclude('*.mp4')->addExclude('*.mp3')->addExclude('*.zip');
@@ -81,7 +81,7 @@ final class ControllerTest extends TestCase
         $this->assertSame($lines, explode("\n", $output->fetch()));
     }
 
-    public function testExcludeShouldBePresentInDatabaseCommand(): void
+    public function testExcludeShouldBePresentInDatabaseCommand()
     {
         $config = new GlobalConfig();
         $config->addDatabase('database', 'mysql://test:aaaaaaaa@127.0.0.1/testdb')->addExclude('table1')->addExclude('table2');
@@ -101,7 +101,7 @@ final class ControllerTest extends TestCase
         $this->assertSame($lines, explode("\n", $output->fetch()));
     }
 
-    public function testAllOptionShouldOverwriteExcludes(): void
+    public function testAllOptionShouldOverwriteExcludes()
     {
         $config = new GlobalConfig();
         $config->addFilesystem('fileadmin', 'fileadmin')->addExclude('*.mp4')->addExclude('*.mp3')->addExclude('*.zip');
@@ -124,7 +124,7 @@ final class ControllerTest extends TestCase
         $this->assertSame($lines, explode("\n", $output->fetch()));
     }
 
-    public function testNoDbOptionShouldRemoveDatabaseCommand(): void
+    public function testNoDbOptionShouldRemoveDatabaseCommand()
     {
         $config = new GlobalConfig();
         $config->addFilesystem('fileadmin', 'fileadmin')->addExclude('*.mp4')->addExclude('*.mp3')->addExclude('*.zip');
@@ -145,7 +145,7 @@ final class ControllerTest extends TestCase
         $this->assertSame($lines, explode("\n", $output->fetch()));
     }
 
-    public function testNoFileOptionShouldRemoveDatabaseCommand(): void
+    public function testNoFileOptionShouldRemoveDatabaseCommand()
     {
         $config = new GlobalConfig();
         $config->addFilesystem('fileadmin', 'fileadmin')->addExclude('*.mp4')->addExclude('*.mp3')->addExclude('*.zip');
@@ -166,7 +166,7 @@ final class ControllerTest extends TestCase
         $this->assertSame($lines, explode("\n", $output->fetch()));
     }
 
-    public function testUseCaseWithoutGlobalDatabase(): void
+    public function testUseCaseWithoutGlobalDatabase()
     {
         $config = new GlobalConfig();
         $config->addSshConnection('projectEu', 'ssh://project@project.com');
@@ -186,7 +186,7 @@ final class ControllerTest extends TestCase
         $this->assertSame($lines, explode(PHP_EOL, $output->fetch()));
     }
 
-    public function testUseCaseDatabaseOnlyDefinedOnOneEnd(): void
+    public function testUseCaseDatabaseOnlyDefinedOnOneEnd()
     {
         $config = new GlobalConfig();
         $config->addSshConnection('projectEu', 'ssh://project@project.com');
@@ -210,7 +210,7 @@ final class ControllerTest extends TestCase
         $this->assertSame($lines, explode("\n", $output->fetch()));
     }
 
-    public function testSyncOutputHasSectionsWithEmptyConfigAndConsoleOutput(): void
+    public function testSyncOutputHasSectionsWithEmptyConfigAndConsoleOutput()
     {
         $config = new GlobalConfig();
         $config->addAppInstance('production', 'localhost', __DIR__);
@@ -225,7 +225,7 @@ final class ControllerTest extends TestCase
         $this->assertEquals("--------------------\n", stream_get_contents($output->getStream()), 'Asserting result empty since config is empty as well');
     }
 
-    public function testSyncOutputHasSectionsWithEmptyConfigAndBufferedOutput(): void
+    public function testSyncOutputHasSectionsWithEmptyConfigAndBufferedOutput()
     {
         $config = new GlobalConfig();
         $config->addAppInstance('production', 'localhost', __DIR__);
@@ -240,7 +240,7 @@ final class ControllerTest extends TestCase
         $this->assertEquals('', $output->fetch(), 'Excepting sync to do nothing');
     }
 
-    public function testSshOutputPassthruExecution(): void
+    public function testSshOutputPassthruExecution()
     {
         $controller = new Controller();
         $config = new GlobalConfig();

--- a/tests/Helper/InternalHelperTest.php
+++ b/tests/Helper/InternalHelperTest.php
@@ -10,15 +10,15 @@ use PHPUnit\Framework\TestCase;
 
 class InternalHelperTest extends TestCase
 {
-    private const GIT_PATH = __DIR__ . '/../../.git';
+    const GIT_PATH = __DIR__ . '/../../.git';
 
-    public function testGetPhpsuVersionFromVendor(): void
+    public function testGetPhpsuVersionFromVendor()
     {
         $result = $this->callPrivateMethod('getPhpSuVersionFromVendor');
         $this->assertEmpty($result, 'Asserting phpsu-vendor version to be empty due to test context');
     }
 
-    public function testGetPhpSuVersionFromGitFolder(): void
+    public function testGetPhpSuVersionFromGitFolder()
     {
         $this->assertFileExists(self::GIT_PATH . '/HEAD');
         if (file_exists(self::GIT_PATH . '/HEAD')) {

--- a/tests/Helper/StringHelperTest.php
+++ b/tests/Helper/StringHelperTest.php
@@ -9,25 +9,25 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class StringHelperTest extends TestCase
 {
-    public function testThatSplitStringSplitsAtRightPosition(): void
+    public function testThatSplitStringSplitsAtRightPosition()
     {
         $result = StringHelper::splitString('test 12_1 12_2 12_3', 10);
         $this->assertSame(['test 12_1', '12_2 12_3'], $result);
     }
 
-    public function testThatSplitStringCannotForceSplit(): void
+    public function testThatSplitStringCannotForceSplit()
     {
         $result = StringHelper::splitString('test_test_test_test', 10);
         $this->assertSame(['test_test_test_test'], $result);
     }
 
-    public function testThatSplitStringCanSplitLarge(): void
+    public function testThatSplitStringCanSplitLarge()
     {
         $result = StringHelper::splitString('test test_test_test_test_test_test_test_test_test', 30);
         $this->assertSame(['test', 'test_test_test_test_test_test_test_test_test'], $result);
     }
 
-    public function testFindStringInArray(): void
+    public function testFindStringInArray()
     {
         $this->assertSame('production', StringHelper::findStringInArray('production', ['production']), 'perfect match');
         $this->assertSame('production', StringHelper::findStringInArray('p', ['production']), 'only first letter');
@@ -38,7 +38,7 @@ class StringHelperTest extends TestCase
         $this->assertSame('', StringHelper::findStringInArray('', ['london', 'local']), 'empty input');
     }
 
-    public function testUndefinedVerbosityException(): void
+    public function testUndefinedVerbosityException()
     {
         $verbosity = 9999;
         $this->expectExceptionMessage("Verbosity $verbosity is not defined");

--- a/tests/Process/CommandExecutorTest.php
+++ b/tests/Process/CommandExecutorTest.php
@@ -12,14 +12,14 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 
 class CommandExecutorTest extends TestCase
 {
-    public function testPassthruPassesSuccessfullyThrough(): void
+    public function testPassthruPassesSuccessfullyThrough()
     {
         $commandExecutor = new CommandExecutor();
         $exitCode = $commandExecutor->passthru('echo "foo" >> /dev/null');
         $this->assertEquals(0, $exitCode);
     }
 
-    public function testPassthruPassesUnsuccessfullyThrough(): void
+    public function testPassthruPassesUnsuccessfullyThrough()
     {
         $commandExecutor = new CommandExecutor();
         $exitCode = $commandExecutor->passthru('ewj 2> /dev/null');
@@ -27,7 +27,7 @@ class CommandExecutorTest extends TestCase
         $this->assertEquals(127, $exitCode, 'command shouldn\'t be installed');
     }
 
-    public function testExecuteCommandsParallel(): void
+    public function testExecuteCommandsParallel()
     {
         $commandExecutor = new CommandExecutor();
         $outputLog = new BufferedOutput();

--- a/tests/Process/OutputCallbackTest.php
+++ b/tests/Process/OutputCallbackTest.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 final class OutputCallbackTest extends TestCase
 {
-    public function testProcessColorStd(): void
+    public function testProcessColorStd()
     {
         $output = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, true);
         $callback = new OutputCallback($output);
@@ -19,7 +19,7 @@ final class OutputCallbackTest extends TestCase
         $this->assertSame('', $output->fetch());
     }
 
-    public function testProcessColorStdVerbose(): void
+    public function testProcessColorStdVerbose()
     {
         $output = new BufferedOutput(OutputInterface::VERBOSITY_VERBOSE, true);
         $callback = new OutputCallback($output);
@@ -27,7 +27,7 @@ final class OutputCallbackTest extends TestCase
         $this->assertSame("\e[33mtestName:\e[39m message\n", $output->fetch());
     }
 
-    public function testProcessColorError(): void
+    public function testProcessColorError()
     {
         $output = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, true);
         $callback = new OutputCallback($output);
@@ -35,7 +35,7 @@ final class OutputCallbackTest extends TestCase
         $this->assertSame("\e[31mtestName:\e[39m message\n", $output->fetch());
     }
 
-    public function testProcessColorErrorMultiline(): void
+    public function testProcessColorErrorMultiline()
     {
         $output = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, true);
         $callback = new OutputCallback($output);
@@ -43,7 +43,7 @@ final class OutputCallbackTest extends TestCase
         $this->assertSame("\e[31mtestName:\e[39m message\n" . "\e[31mtestName:\e[39m message2\n", $output->fetch());
     }
 
-    public function testProcessColorStdVerboseMultiline(): void
+    public function testProcessColorStdVerboseMultiline()
     {
         $output = new BufferedOutput(OutputInterface::VERBOSITY_VERBOSE, true);
         $callback = new OutputCallback($output);
@@ -51,7 +51,7 @@ final class OutputCallbackTest extends TestCase
         $this->assertSame("\e[33mtestName:\e[39m message\n" . "\e[33mtestName:\e[39m message2\n", $output->fetch());
     }
 
-    public function testProcessColorErrQuite(): void
+    public function testProcessColorErrQuite()
     {
         $output = new BufferedOutput(OutputInterface::VERBOSITY_QUIET, true);
         $callback = new OutputCallback($output);
@@ -59,7 +59,7 @@ final class OutputCallbackTest extends TestCase
         $this->assertSame("\e[31mtestName:\e[39m message\n", $output->fetch());
     }
 
-    public function testProcessErr(): void
+    public function testProcessErr()
     {
         $output = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, false);
         $callback = new OutputCallback($output);
@@ -67,7 +67,7 @@ final class OutputCallbackTest extends TestCase
         $this->assertSame("testName: message\n", $output->fetch());
     }
 
-    public function testProcessStdVerbose(): void
+    public function testProcessStdVerbose()
     {
         $output = new BufferedOutput(OutputInterface::VERBOSITY_VERBOSE, false);
         $callback = new OutputCallback($output);
@@ -75,7 +75,7 @@ final class OutputCallbackTest extends TestCase
         $this->assertSame("testName: message\n", $output->fetch());
     }
 
-    public function testProcessMultipleCalls(): void
+    public function testProcessMultipleCalls()
     {
         $output = new BufferedOutput(OutputInterface::VERBOSITY_VERBOSE, true);
         $callback = new OutputCallback($output);

--- a/tests/Process/ProcessManagerTest.php
+++ b/tests/Process/ProcessManagerTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 final class ProcessManagerTest extends TestCase
 {
-    public function testProcessesShouldBeRunning(): void
+    public function testProcessesShouldBeRunning()
     {
         $processManager = new ProcessManager();
         $processManager->addProcess($pList1 = Process::fromShellCommandline('echo "Testing List1" && sleep 0.1')->setName('list1'));
@@ -27,7 +27,7 @@ final class ProcessManagerTest extends TestCase
     /**
      * @expectedException \Exception
      */
-    public function testRunWithError(): void
+    public function testRunWithError()
     {
         (new ProcessManager())
             ->addProcess($pError = Process::fromShellCommandline('error')->setName('error' . md5(random_bytes(100))))
@@ -36,7 +36,7 @@ final class ProcessManagerTest extends TestCase
             ->validateProcesses();
     }
 
-    public function testRunGetErrorOutput(): void
+    public function testRunGetErrorOutput()
     {
         $processManager = new ProcessManager();
         $name = 'error' . md5(random_bytes(100));
@@ -52,7 +52,7 @@ final class ProcessManagerTest extends TestCase
         $this->assertTrue(false, 'Exception should be thrown');
     }
 
-    public function testAddOutputCallback(): void
+    public function testAddOutputCallback()
     {
         $processManager = new ProcessManager();
         $processManager->addOutputCallback(function () {
@@ -65,7 +65,7 @@ final class ProcessManagerTest extends TestCase
         }
     }
 
-    public function testAddStateChangeCallback(): void
+    public function testAddStateChangeCallback()
     {
         $processManager = new ProcessManager();
         $processManager->addStateChangeCallback(function () {
@@ -78,7 +78,7 @@ final class ProcessManagerTest extends TestCase
         }
     }
 
-    public function testAddTickCallback(): void
+    public function testAddTickCallback()
     {
         $processManager = new ProcessManager();
         $processManager->addTickCallback(function () {
@@ -91,7 +91,7 @@ final class ProcessManagerTest extends TestCase
         }
     }
 
-    public function testProcessManagerMustRun(): void
+    public function testProcessManagerMustRun()
     {
         $result = (new ProcessManager())
             ->addProcess($pError = Process::fromShellCommandline('echo hi'))

--- a/tests/Process/ProcessPolyfillTest.php
+++ b/tests/Process/ProcessPolyfillTest.php
@@ -13,21 +13,21 @@ use Symfony\Component\Process\Exception\ProcessFailedException;
 class ProcessPolyfillTest extends TestCase
 {
 
-    public function testSuccessfulProcessCommandOutput(): void
+    public function testSuccessfulProcessCommandOutput()
     {
         $result = (new CommandExecutor())->runCommand('echo hi');
         $this->assertEquals($result->getOutput(), 'hi' . PHP_EOL, 'Executor output was correct: hi');
         $this->assertEmpty($result->getErrorOutput(), 'Executor error output was correctly empty');
     }
 
-    public function testErrorProcessCommandOutput(): void
+    public function testErrorProcessCommandOutput()
     {
         $result = (new CommandExecutor())->runCommand('oijewfoijwfj');
         $this->assertEmpty($result->getOutput(), 'Executor output was correctly empty');
         $this->assertNotEmpty($result->getErrorOutput(), 'Executor error output was correctly not empty');
     }
 
-    public function testNewProcessSymfonyOlder3dot4(): void
+    public function testNewProcessSymfonyOlder3dot4()
     {
         if (version_compare((new EnvironmentUtility())->getSymfonyProcessVersion(), '3.4.0', '<')) {
             $process = new Process('echo');
@@ -39,7 +39,7 @@ class ProcessPolyfillTest extends TestCase
         $this->markTestSkipped('Installed version is not older than 3.4.0');
     }
 
-    public function testNewProcessSymfonyNewer3dot4(): void
+    public function testNewProcessSymfonyNewer3dot4()
     {
         if (version_compare((new EnvironmentUtility())->getSymfonyProcessVersion(), '3.4.0', '>=')) {
             $process = new Process([]);
@@ -49,7 +49,7 @@ class ProcessPolyfillTest extends TestCase
         $this->markTestSkipped('Installed version is not newer than 3.4.0');
     }
 
-    public function testNewProcessSymfonyNewer4dot2(): void
+    public function testNewProcessSymfonyNewer4dot2()
     {
         if (version_compare((new EnvironmentUtility())->getSymfonyProcessVersion(), '4.2.0', '>=')) {
             $this->expectException(CommandExecutionException::class);

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class ProcessTest extends TestCase
 {
-    public function testImpossibleStateException(): void
+    public function testImpossibleStateException()
     {
         $process = Process::fromShellCommandline('');
         $reflection =  (new \ReflectionClass($process))->getParentClass()->getProperty('status');

--- a/tests/Process/SpinnerTest.php
+++ b/tests/Process/SpinnerTest.php
@@ -8,14 +8,14 @@ use PHPUnit\Framework\TestCase;
 
 class SpinnerTest extends TestCase
 {
-    public function testSpinForRandomState(): void
+    public function testSpinForRandomState()
     {
         $number = \random_int(0, \count(Spinner::PONG) - 1);
         $spinner = $this->setSpinnerStateToNumber(new Spinner, $number);
         $this->assertSame(Spinner::PONG[$number], $spinner->spin());
     }
 
-    public function testSpinForLargeNumberToZeroAsState(): void
+    public function testSpinForLargeNumberToZeroAsState()
     {
         $number = 100000000000000;
         $spinner = $this->setSpinnerStateToNumber(new Spinner, $number);

--- a/tests/Process/StateChangeCallbackTest.php
+++ b/tests/Process/StateChangeCallbackTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Output\ConsoleSectionOutput;
 
 final class StateChangeCallbackTest extends TestCase
 {
-    public function testNormalReady(): void
+    public function testNormalReady()
     {
         $output = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, true);
         $manager = new ProcessManager();
@@ -24,7 +24,7 @@ final class StateChangeCallbackTest extends TestCase
         $this->assertSame("\e[37msleepProcess:\e[39m  \n", $output->fetch());
     }
 
-    public function testNormalRunning(): void
+    public function testNormalRunning()
     {
         $output = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, true);
         $manager = new ProcessManager();
@@ -33,7 +33,7 @@ final class StateChangeCallbackTest extends TestCase
         $this->assertSame("\e[33msleepProcess:\e[39m (      )\n", $output->fetch());
     }
 
-    public function testNormalSucceeded(): void
+    public function testNormalSucceeded()
     {
         $output = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, true);
         $manager = new ProcessManager();
@@ -42,7 +42,7 @@ final class StateChangeCallbackTest extends TestCase
         $this->assertSame("\e[32msleepProcess:\e[39m ✔\n", $output->fetch());
     }
 
-    public function testNormalErrored(): void
+    public function testNormalErrored()
     {
         $output = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, true);
         $manager = new ProcessManager();
@@ -51,7 +51,7 @@ final class StateChangeCallbackTest extends TestCase
         $this->assertSame("\e[31msleepProcess:\e[39m ✘\n", $output->fetch());
     }
 
-    public function testSectionReady(): void
+    public function testSectionReady()
     {
         $sections = [];
         $outputStream = fopen('php://memory', 'rwb');
@@ -63,7 +63,7 @@ final class StateChangeCallbackTest extends TestCase
         $this->assertSame("\n", stream_get_contents($outputStream));
     }
 
-    public function testSectionReadyWithProcess(): void
+    public function testSectionReadyWithProcess()
     {
         $sections = [];
         $outputStream = fopen('php://memory', 'rwb');
@@ -77,7 +77,7 @@ final class StateChangeCallbackTest extends TestCase
         $this->assertSame("\e[37msleepProcess:\e[39m  \n", stream_get_contents($outputStream));
     }
 
-    public function testSectionRunningWithProcess(): void
+    public function testSectionRunningWithProcess()
     {
         $sections = [];
         $outputStream = fopen('php://memory', 'rwb');
@@ -100,7 +100,7 @@ final class StateChangeCallbackTest extends TestCase
         );
     }
 
-    public function testSectionRunningWithProcessSpinner(): void
+    public function testSectionRunningWithProcessSpinner()
     {
         $sections = [];
         $outputStream = fopen('php://memory', 'rwb');
@@ -136,7 +136,7 @@ final class StateChangeCallbackTest extends TestCase
         );
     }
 
-    public function setPrivateProperty($object, string $propertyName, $value): void
+    public function setPrivateProperty($object, string $propertyName, $value)
     {
         $property = (new \ReflectionClass($object))->getProperty($propertyName);
         $property->setAccessible(true);

--- a/tests/Tools/ConsoleSectionOutputPolyfillTest.php
+++ b/tests/Tools/ConsoleSectionOutputPolyfillTest.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Output\StreamOutput;
 
 class ConsoleSectionOutputPolyfillTest extends TestCase
 {
-    public function testConsoleSectionOutputPolyfill(): void
+    public function testConsoleSectionOutputPolyfill()
     {
         $sectionOutputs = [];
         $output = new StreamOutput(fopen('php://memory', 'w', false));

--- a/tests/Tools/EnvironmentUtilityTest.php
+++ b/tests/Tools/EnvironmentUtilityTest.php
@@ -8,17 +8,17 @@ use PHPUnit\Framework\TestCase;
 
 class EnvironmentUtilityTest extends TestCase
 {
-    public function testCommandIsInstalled(): void
+    public function testCommandIsInstalled()
     {
         $this->assertEquals(true, (new EnvironmentUtility())->isCommandInstalled('echo'));
     }
 
-    public function testCommandIsNotInstalled(): void
+    public function testCommandIsNotInstalled()
     {
         $this->assertEquals(false, (new EnvironmentUtility())->isCommandInstalled('reiguheruh'));
     }
 
-    public function testGetInstalledRsyncVersionOrExpectExceptionIfNotInstalled(): void
+    public function testGetInstalledRsyncVersionOrExpectExceptionIfNotInstalled()
     {
         if ((new EnvironmentUtility())->isRsyncInstalled()) {
             $rsyncVersion = (new EnvironmentUtility())->getRsyncVersion();
@@ -29,7 +29,7 @@ class EnvironmentUtilityTest extends TestCase
         }
     }
 
-    public function testGetInstalledSshVersionOrExpectExceptionIfNotInstalled(): void
+    public function testGetInstalledSshVersionOrExpectExceptionIfNotInstalled()
     {
         if ((new EnvironmentUtility())->isSshInstalled()) {
             $sshVersion = (new EnvironmentUtility())->getSshVersion();
@@ -40,7 +40,7 @@ class EnvironmentUtilityTest extends TestCase
         }
     }
 
-    public function testGetInstalledMysqldumpVersionOrExpectExceptionIfNotInstalled(): void
+    public function testGetInstalledMysqldumpVersionOrExpectExceptionIfNotInstalled()
     {
         if ((new EnvironmentUtility())->isMysqlDumpInstalled()) {
             $mysqldumpVersion = (new EnvironmentUtility())->getMysqlDumpVersion();
@@ -52,13 +52,13 @@ class EnvironmentUtilityTest extends TestCase
         }
     }
 
-    public function testGetInstalledSymfonyConsoleVersion(): void
+    public function testGetInstalledSymfonyConsoleVersion()
     {
         $symfonyConsoleVersion = (new EnvironmentUtility())->getSymfonyConsoleVersion();
         $this->assertEquals(1, version_compare($symfonyConsoleVersion, '3.0.0'));
     }
 
-    public function testGetInstalledSymfonyProcessVersion(): void
+    public function testGetInstalledSymfonyProcessVersion()
     {
         $symfonyConsoleVersion = (new EnvironmentUtility())->getSymfonyProcessVersion();
         $this->assertEquals(1, version_compare($symfonyConsoleVersion, '3.0.0'));


### PR DESCRIPTION
## Description and Background

We still have Projects with php 7.0.

## Motivation and Context

This change is keeped in a Single Commit, so we maybe can revert it easily at a later point in Time.

## How Has This Been Tested

All the test have passed. 
I have run the commands in php 7.0.

#### Checklist

- [x] My code follows the PSR coding guideline.
- [x] I have updated the `documentation` accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added `tests` to cover my changes.
- [x] All new and existing tests passed.
