### PR TITLE
throw exception when no appinstance is configured for ssh cli command

### DIFF
--- a/src/Cli/SshCliCommand.php
+++ b/src/Cli/SshCliCommand.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace PHPSu\Cli;
 
+use Exception;
+use function in_array;
 use PHPSu\Config\AppInstance;
 use PHPSu\Helper\StringHelper;
 use PHPSu\Options\SshOptions;
@@ -45,11 +47,15 @@ final class SshCliCommand extends AbstractCliCommand
 
     /**
      * @return void
+     * @throws Exception
      */
     protected function interact(InputInterface $input, OutputInterface $output)
     {
         $default = $input->hasArgument('destination') ? $this->getArgument($input, 'destination') : '';
-        if (!\in_array($default, $this->getAppInstancesWithHost(), true)) {
+        if (empty($this->getAppInstancesWithHost())) {
+            throw new Exception('You need to define at least one AppInstance besides local');
+        }
+        if (!in_array($default, $this->getAppInstancesWithHost(), true)) {
             $question = new ChoiceQuestion('Please select one of the AppInstances', $this->getAppInstancesWithHost());
             $question->setErrorMessage('AppInstance %s not found in Config.');
             $destination = $this->getHelper('question')->ask($input, $output, $question);

--- a/tests/Cli/SshCliCommandTest.php
+++ b/tests/Cli/SshCliCommandTest.php
@@ -92,6 +92,23 @@ class SshCliCommandTest extends TestCase
         $this->assertSame(208, $commandTester->getStatusCode());
     }
 
+    public function testSshCliCommandExecuteWithNoAppInstancesConfigured()
+    {
+        $globalConfig = $this->createConfigNoAppInstance();
+        $mockConfigurationLoader = $this->createMockConfigurationLoader($globalConfig);
+
+        /** @var MockObject|ControllerInterface $mockController */
+        $mockController = $this->createMock(ControllerInterface::class);
+
+        $command = new SshCliCommand($mockConfigurationLoader, $mockController);
+        $command->setHelperSet(new HelperSet([new QuestionHelper()]));
+        $commandTester = new CommandTester($command);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('You need to define at least one AppInstance besides local');
+        $commandTester->execute(['destination' => 'p']);
+    }
+
     /**
      * @return GlobalConfig
      */
@@ -100,6 +117,16 @@ class SshCliCommandTest extends TestCase
         $globalConfig = new GlobalConfig();
         $globalConfig->addSshConnection('us', 'ssh://user@us');
         $globalConfig->addAppInstance('production', 'us', '/var/www/');
+        return $globalConfig;
+    }
+
+    /**
+     * @return GlobalConfig
+     */
+    private function createConfigNoAppInstance(): GlobalConfig
+    {
+        $globalConfig = new GlobalConfig();
+        $globalConfig->addSshConnection('us', 'ssh://user@us');
         return $globalConfig;
     }
 


### PR DESCRIPTION
## Description and Background

When using phpsu ssh and no AppInstance was defined, then the program ran into an undefined and unclear exception.



- [x] My code follows the PSR coding guideline.
- [-] I have updated the `documentation` accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added `tests` to cover my changes.
- [x] All new and existing tests passed.
